### PR TITLE
Fixed path for config files

### DIFF
--- a/src/Deployer/Task/MagentoTasks.php
+++ b/src/Deployer/Task/MagentoTasks.php
@@ -138,7 +138,7 @@ class MagentoTasks extends TaskAbstract
         }
 
         \Deployer\cd('{{release_path_app}}');
-        \Deployer\run("php bin/magento config:data:import ../config/store $env");
+        \Deployer\run("php bin/magento config:data:import config/store $env");
     }
 
     /**


### PR DESCRIPTION
The CONFIG_DATA_IMPORT task was failing to locate config files because the path was looking for them one level above the release_path but Semaio recommended folder organization is right at the release path level