### PR TITLE
Bugfix #3 - Replace realpath call with readlink

### DIFF
--- a/src/Deployer/Task/DeployTasks.php
+++ b/src/Deployer/Task/DeployTasks.php
@@ -108,7 +108,7 @@ class DeployTasks extends TaskAbstract
         $path = \Deployer\get('deploy_path');
         $hasReleasePathStable = \Deployer\run("if [ -d $path/current/ ]; then echo 'true'; fi")->toBool();
         if ($hasReleasePathStable) {
-            $releasePathStable = (string)\Deployer\run("realpath $path/current/");
+            $releasePathStable = (string)\Deployer\run("readlink -f $path/current/");
             \Deployer\set('release_path_stable', $releasePathStable);
         }
         if (\Deployer\isVerbose()) {


### PR DESCRIPTION
The deployment is failing due to missing tool "realpath". This tool is not provided anymore in many Linux distro.