### PR TITLE
feat: add support for zstd compression

### DIFF
--- a/src/Deployer/Recipe/Magento2Recipe.php
+++ b/src/Deployer/Recipe/Magento2Recipe.php
@@ -72,6 +72,8 @@ class Magento2Recipe
 
         \Deployer\set('artifacts_dir', 'artifacts');
 
+        \Deployer\set('artifacts_compression', 'gz');
+
         $artifacts = [
             'shop.tar.gz',
         ];

--- a/src/Deployer/Task/BuildTasks.php
+++ b/src/Deployer/Task/BuildTasks.php
@@ -104,10 +104,19 @@ class BuildTasks extends TaskAbstract
      */
     protected static function uploadAndExtract($tarFile)
     {
+        $compression = \Deployer\get('artifacts_compression');
+        $tarOptions = '';
+
+        if ($compression === 'gz') {
+            $tarOptions = 'xfz';
+        } elseif ($compression === 'zstd') {
+            $tarOptions = '-I \'zstd -T0\' -xf';
+        }
+
         $releasePath = '{{release_path}}';
 
         \Deployer\upload("{{artifacts_dir}}/$tarFile", "$releasePath/$tarFile");
-        \Deployer\run("cd $releasePath; tar xfz $releasePath/$tarFile");
+        \Deployer\run("cd $releasePath; tar $tarOptions $releasePath/$tarFile");
         \Deployer\run("rm $releasePath/$tarFile");
     }
 


### PR DESCRIPTION
This merge request adds the possibility to use zstd as the compression for the artifacts that gets uploaded.

So you need to set  **artifacts_compression** to **zstd** and change **magento_build_artifacts** to have files with "tar.zst" as the file ending.